### PR TITLE
Remove placeholder icon image files

### DIFF
--- a/icon128.png
+++ b/icon128.png
@@ -1,1 +1,0 @@
-Placeholder for 128x128 icon

--- a/icon16.png
+++ b/icon16.png
@@ -1,1 +1,0 @@
-Placeholder for 16x16 icon

--- a/icon48.png
+++ b/icon48.png
@@ -1,1 +1,0 @@
-Placeholder for 48x48 icon


### PR DESCRIPTION
Deleted icon16.png, icon48.png, and icon128.png placeholder files that are no longer needed.